### PR TITLE
Feat/pki retention

### DIFF
--- a/utils/configurator/configure_node_2.7.py
+++ b/utils/configurator/configure_node_2.7.py
@@ -7,6 +7,7 @@ import yaml
 import json
 import sys
 import posixpath
+import shlex
 
 
 # Helper program for CLI argument programming of cave mesh nodes
@@ -139,7 +140,7 @@ def runProgramCaptureOutput(args):
 def runCmd(cmd, echoOnly=False, silent=False, reboot=False):
     print(f"Running command: {cmd}")
     if not echoOnly:
-        args = cmd.split()
+        args = shlex.split(cmd)
         output = runProgramCaptureOutput(args)
         if not silent:
             lines = output.stdout.split('\n')
@@ -343,6 +344,156 @@ def checkFirmwareVersion(info_output):
                     raise RuntimeWarning ("This is not the correct configurator for FW version FW_version."\
                                           " The output formats are different. Use the correct configurator version.")
 
+def extractKeysFromInfo(info_output, meshcmd):
+    """
+    Extract nodeId, private key, and public key from device info output.
+    Returns dict with nodeId, private_key, public_key, or None if extraction fails.
+    nodeId is in hex format with ! prefix (e.g., "!710c5ed7")
+    """
+    nodeId = None
+    public_key = None
+    private_key = None
+
+    # Extract nodeId from "My info" line - convert myNodeNum to hex with ! prefix
+    for line in info_output.splitlines():
+        if line.startswith("My info"):
+            try:
+                json_str = line.split(':', maxsplit=1)[-1].strip()
+                my_info = json.loads(json_str)
+                myNodeNum = my_info.get('myNodeNum')
+                if myNodeNum:
+                    # Convert to hex and add ! prefix
+                    nodeId = f"!{myNodeNum:08x}"
+            except Exception as e:
+                print(f"ERROR: Failed to parse My info line: {e}")
+                return None
+
+    # Extract keys from "security" section
+    lines = info_output.splitlines()
+    security_lines = []
+    in_security = False
+    bcount = 0
+
+    for line in lines:
+        if '"security":' in line or '"security" :' in line:
+            security_lines.append(line)
+            in_security = True
+            bcount = 1
+            continue
+        if in_security:
+            security_lines.append(line)
+            if '{' in line:
+                bcount += line.count('{')
+            if '}' in line:
+                bcount -= line.count('}')
+            if bcount == 0:
+                break
+
+    if len(security_lines) > 0:
+        try:
+            security_text = '\n'.join(security_lines)
+            security_text = security_text.rstrip(',')
+            security_data = yaml.safe_load(security_text)
+            security_dict = security_data.get('security', {})
+            public_key = security_dict.get('publicKey')
+            private_key = security_dict.get('privateKey')
+        except Exception as e:
+            print(f"WARNING: Failed to parse security section: {e}")
+
+    if nodeId and public_key and private_key:
+        return {
+            'nodeId': nodeId,
+            'public_key': public_key,
+            'private_key': private_key
+        }
+    else:
+        print(f"WARNING: Failed to extract all keys. nodeId={nodeId}, public_key={'found' if public_key else 'missing'}, private_key={'found' if private_key else 'missing'}")
+        return None
+
+def writeKeysToFile(nodeId, private_key, public_key, config_file):
+    """
+    Write or update keys entry in keys.txt file.
+    If entry with same nodeId exists, replace it. Otherwise append.
+    Format: nodeId,private_key,public_key,config_file
+    """
+    keys_file = "keys.txt"
+    entries = []
+    header = "nodeId,private_key,public_key,config_file"
+    has_header = False
+
+    # Read existing entries
+    if os.path.exists(keys_file):
+        try:
+            with open(keys_file, 'r') as f:
+                first_line = True
+                for line in f:
+                    line = line.strip()
+                    if first_line and line == header:
+                        has_header = True
+                        first_line = False
+                        continue
+                    if line and not line.startswith('#'):
+                        # Format: nodeId,private_key,public_key,config_file
+                        parts = line.split(',', 3)
+                        if len(parts) == 4:
+                            existing_nodeId = parts[0].strip()
+                            # Skip if this is the nodeId we're updating
+                            if existing_nodeId != nodeId:
+                                entries.append(line)
+                    first_line = False
+        except Exception as e:
+            print(f"WARNING: Error reading keys.txt: {e}")
+
+    # Add or update entry
+    new_entry = f"{nodeId},{private_key},{public_key},{config_file}"
+    entries.append(new_entry)
+
+    # Write back to file
+    try:
+        with open(keys_file, 'w') as f:
+            f.write(header + '\n')
+            for entry in entries:
+                f.write(entry + '\n')
+        print(f"Wrote keys to {keys_file} for nodeId {nodeId}")
+    except Exception as e:
+        print(f"ERROR: Failed to write keys.txt: {e}")
+
+def readKeysFromFile(nodeId):
+    """
+    Read keys from keys.txt for a given nodeId.
+    Returns dict with private_key, public_key, config_file, or None if not found.
+    """
+    keys_file = "keys.txt"
+
+    if not os.path.exists(keys_file):
+        return None
+
+    try:
+        with open(keys_file, 'r') as f:
+            first_line = True
+            for line in f:
+                line = line.strip()
+                # Skip header line
+                if first_line and line == "nodeId,private_key,public_key,config_file":
+                    first_line = False
+                    continue
+                if line and not line.startswith('#'):
+                    # Format: nodeId,private_key,public_key,config_file
+                    parts = line.split(',', 3)
+                    if len(parts) == 4:
+                        existing_nodeId = parts[0].strip()
+                        if existing_nodeId == nodeId:
+                            return {
+                                'private_key': parts[1].strip(),
+                                'public_key': parts[2].strip(),
+                                'config_file': parts[3].strip()
+                            }
+                first_line = False
+    except Exception as e:
+        print(f"ERROR: Failed to read keys.txt: {e}")
+
+    return None
+
 def getNodeDb(infocmd):
     device_info = runCmd(infocmd, echoOnly=False, silent=True)
     lines = device_info.splitlines()
@@ -453,6 +604,8 @@ def main():
                         help='factory reset node before starting.')
     parser.add_argument('-cd', '--clear-db',action='store_true',
                         help='clears database, use if meshtastic --reset-nodedb does delete all nodes')
+    parser.add_argument('-rk', '--retain-keys',action='store_true',
+                        help='retain previous keys from keys.txt if available, otherwise keep existing keys')
 
     
     args = parser.parse_args()
@@ -523,12 +676,37 @@ def main():
         if channels:
             if not args.test:
                 doCompareChannels(device_info)
+        # Write keys to keys.txt even when not in set mode
+        if not args.test:
+            keys_info = extractKeysFromInfo(device_info, meshcmd)
+            if keys_info:
+                writeKeysToFile(keys_info['nodeId'], keys_info['private_key'],
+                              keys_info['public_key'], args.settingsFile)
         
     else:
+        # Handle key retention if requested (before setting any other settings)
+        if args.retain_keys and not args.test:
+            info_out = runCmd(infocmd, echoOnly=args.test, silent=True)
+            keys_info = extractKeysFromInfo(info_out, meshcmd)
+            if keys_info and keys_info.get('nodeId'):
+                saved_keys = readKeysFromFile(keys_info['nodeId'])
+                if saved_keys:
+                    print(f"Restoring keys from keys.txt for nodeId {keys_info['nodeId']}")
+                    # Set the keys using meshtastic commands
+                    set_private_cmd = f"{meshcmd} --set security.private_key base64:{saved_keys['private_key']}"
+                    # set_public_cmd = f"{meshcmd} --set security.public_key {saved_keys['public_key']}"
+                    runCmd(set_private_cmd, echoOnly=args.test, reboot=(not args.test))
+                    # runCmd(set_public_cmd, echoOnly=args.test, reboot=(not args.test))
+                    print("Keys restored successfully")
+                else:
+                    print(f"No previous keys found in keys.txt for nodeId {keys_info['nodeId']}, keeping existing keys")
+            else:
+                print("WARNING: Could not extract nodeId, cannot restore keys")
+
         num_retries = 0
         while num_retries < max_retries:
             # Need to do a get so that compare settings
-            info_out = runCmd("meshtastic --info",echoOnly=args.test) # user info is on line 3
+            info_out = runCmd(infocmd, echoOnly=args.test) # user info is on line 3
             checkFirmwareVersion(info_out)
 
             output = "\n".join(info_out.splitlines()[:5])
@@ -561,7 +739,7 @@ def main():
                     if key == "user.longname":
                         setcmd += f" --set-owner '{value}'"
                     elif key == "user.shortname":
-                        setcmd += f" --set-owner-short '{value}'"
+                        setcmd += f" --set-owner-short {value}"
                     elif key == "security.admin_key":
                         continue # need to be done separately - too big.
                     else:
@@ -605,6 +783,11 @@ def main():
             
     if not args.test:
         printDeviceInfo(device_info)
+        # Write keys to keys.txt
+        keys_info = extractKeysFromInfo(device_info, meshcmd)
+        if keys_info:
+            writeKeysToFile(keys_info['nodeId'], keys_info['private_key'],
+                          keys_info['public_key'], args.settingsFile)
 
     if args.export_config:
         if longname:

--- a/utils/configurator/create_keys_from_infofiles.py
+++ b/utils/configurator/create_keys_from_infofiles.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+Extract keys from info files in a directory and write them to keys.txt.
+This script parses all .txt files in the specified directory (default: infofiles)
+and extracts nodeId, private key, and public key from each, writing them to keys.txt.
+
+
+# Usage:
+Run from utils/configurator/
+
+This is to be run once, targeting the folder that has your info files, and will create a keys.txt file. 
+The files are parsed from oldest modified, so the most recent key should be retained.
+
+It should be able to be run multiple times, but as 'last updated' is not retained, an old log will take precedence over an existing entry in keys.txt.
+
+"""
+
+import os
+import sys
+import json
+import yaml
+import argparse
+import glob
+
+def extractKeysFromInfoFile(info_content):
+    """
+    Extract nodeId, private key, and public key from device info file content.
+    Returns dict with nodeId, private_key, public_key, or None if extraction fails.
+    nodeId is in hex format with ! prefix (e.g., "!710c5ed7")
+    """
+    nodeId = None
+    public_key = None
+    private_key = None
+    
+    # Extract nodeId from "My info" line - convert myNodeNum to hex with ! prefix
+    for line in info_content.splitlines():
+        if line.startswith("My info"):
+            try:
+                json_str = line.split(':', maxsplit=1)[-1].strip()
+                my_info = json.loads(json_str)
+                myNodeNum = my_info.get('myNodeNum')
+                if myNodeNum:
+                    # Convert to hex and add ! prefix
+                    nodeId = f"!{myNodeNum:08x}"
+            except Exception as e:
+                print(f"ERROR: Failed to parse My info line: {e}")
+                return None
+    
+    # Extract keys from "security" section
+    lines = info_content.splitlines()
+    security_lines = []
+    in_security = False
+    bcount = 0
+    
+    for line in lines:
+        if '"security":' in line or '"security" :' in line:
+            security_lines.append(line)
+            in_security = True
+            bcount = 1
+            continue
+        if in_security:
+            security_lines.append(line)
+            if '{' in line:
+                bcount += line.count('{')
+            if '}' in line:
+                bcount -= line.count('}')
+            if bcount == 0:
+                break
+    
+    if len(security_lines) > 0:
+        try:
+            security_text = '\n'.join(security_lines)
+            # Remove everything before the first '{'
+            # brace_idx = security_text.find('{')
+            # if brace_idx != -1:
+            #     security_text = security_text[brace_idx:]
+            # For all lines in security_lines, strip starting white space
+
+            # security_text = [line.lstrip() for line in security_text]
+            security_text = security_text.rstrip(',')
+            print("---")
+            print(security_text)
+            print("---")
+            security_data = yaml.safe_load(security_text)
+            security_dict = security_data.get('security', {})
+            public_key = security_dict.get('publicKey')
+            private_key = security_dict.get('privateKey')
+        except Exception as e:
+            print(f"WARNING: Failed to parse security section: {e}")
+    
+    if nodeId and public_key and private_key:
+        return {
+            'nodeId': nodeId,
+            'public_key': public_key,
+            'private_key': private_key
+        }
+    else:
+        return None
+
+def writeKeysToFile(nodeId, private_key, public_key, config_file, keys_file="keys.txt"):
+    """
+    Write or update keys entry in keys.txt file.
+    If entry with same nodeId exists, replace it. Otherwise append.
+    Format: nodeId,private_key,public_key,config_file
+    """
+    entries = []
+    header = "nodeId,private_key,public_key,config_file"
+    has_header = False
+    
+    # Read existing entries
+    if os.path.exists(keys_file):
+        try:
+            with open(keys_file, 'r') as f:
+                first_line = True
+                for line in f:
+                    line = line.strip()
+                    if first_line and line == header:
+                        has_header = True
+                        first_line = False
+                        continue
+                    if line and not line.startswith('#'):
+                        # Format: nodeId,private_key,public_key,config_file
+                        parts = line.split(',', 3)
+                        if len(parts) == 4:
+                            existing_nodeId = parts[0].strip()
+                            # Skip if this is the nodeId we're updating
+                            if existing_nodeId != nodeId:
+                                entries.append(line)
+                    first_line = False
+        except Exception as e:
+            print(f"WARNING: Error reading {keys_file}: {e}")
+    
+    # Add or update entry
+    new_entry = f"{nodeId},{private_key},{public_key},{config_file}"
+    entries.append(new_entry)
+    
+    # Write back to file
+    try:
+        with open(keys_file, 'w') as f:
+            f.write(header + '\n')
+            for entry in entries:
+                f.write(entry + '\n')
+        return True
+    except Exception as e:
+        print(f"ERROR: Failed to write {keys_file}: {e}")
+        return False
+
+def main():
+    parser = argparse.ArgumentParser(description="Extract keys from info files and write to keys.txt")
+    parser.add_argument('-d', '--directory', dest='directory', type=str,
+                        default='infofiles',
+                        help='Directory containing info files (default: infofiles)')
+    parser.add_argument('-o', '--output', dest='output', type=str,
+                        default='keys.txt',
+                        help='Output keys file (default: keys.txt)')
+    
+    args = parser.parse_args()
+    
+    if not os.path.isdir(args.directory):
+        print(f"ERROR: Directory '{args.directory}' does not exist")
+        sys.exit(1)
+    
+    # Find all .txt files in the directory
+    pattern = os.path.join(args.directory, "*.txt")
+    info_files = glob.glob(pattern)
+    # Sort by modification time, oldest first
+    info_files.sort(key=lambda f: os.path.getmtime(f))
+    
+    if not info_files:
+        print(f"No .txt files found in {args.directory}")
+        sys.exit(0)
+    
+    print(f"Processing {len(info_files)} info file(s) from {args.directory}...")
+    
+    processed = 0
+    failed = 0
+    
+    for info_file in info_files:
+        try:
+            with open(info_file, 'r', encoding='utf-8', errors='ignore') as f:
+                info_content = f.read()
+            
+            keys_info = extractKeysFromInfoFile(info_content)
+            if keys_info:
+                # Use the info filename as the config_file identifier (since we don't know the actual config)
+                config_file = f"from_info_file:{os.path.basename(info_file)}"
+                if writeKeysToFile(keys_info['nodeId'], keys_info['private_key'], 
+                                 keys_info['public_key'], config_file, args.output):
+                    print(f"  ✓ Extracted keys from {os.path.basename(info_file)} (nodeId: {keys_info['nodeId']})")
+                    processed += 1
+                else:
+                    print(f"  ✗ Failed to write keys for {os.path.basename(info_file)}")
+                    failed += 1
+            else:
+                print(f"  ✗ Failed to extract keys from {os.path.basename(info_file)}")
+                failed += 1
+        except Exception as e:
+            print(f"  ✗ Error processing {os.path.basename(info_file)}: {e}")
+            failed += 1
+    
+    print(f"\nCompleted: {processed} file(s) processed successfully, {failed} failed")
+    print(f"Keys written to {args.output}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds private key retention and setting. 
Uses a keys.txt file to do it. 

There's a create keys script to turn existing info files into a keys.txt as well. 

Minor changes to handle setting / logging and otherwise managing longnames with spaces. 
` python configure.xxx.py -ln 'long space filled name'`